### PR TITLE
Feature: User to Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,15 @@ jspm_packages
 .npm
 
 # Sensitive Files
+# Because there is no standard naming convention use
+# https://en.wikipedia.org/wiki/Deployment_environment for base names
 /config/**
 !/config/default*
+!/config/development.*
+!/config/testing.*
+!/config/acceptance.*
+!/config/staging.*
+!/config/production.*
 
 # Optional REPL history
 .node_repl_history

--- a/auth.js
+++ b/auth.js
@@ -5,30 +5,34 @@
 'use strict';
 
 const config = require('config');
-const crypto = require('crypto');
-const uuid = require('uuid');
-const NodeCache = require('node-cache');
+const jwt = require('jsonwebtoken');
 
-const algorithm = 'aes-256-ctr';
-const password = config.get('servers.auth.crypt.password');
-const cacheConfig = config.get('servers.auth.cache');
-const ttl = cacheConfig.ttl;
-const check = cacheConfig.check;
+const secret = config.get('servers.auth.token.secret');
+const ttl = config.get('servers.auth.token.ttl');
 
-const encrypt = (text) => {
-  const cipher = crypto.createCipher(algorithm, password);
-  return cipher.update(text, 'utf8', 'hex') + cipher.final('hex');
+const encrypt = (text, done) => {
+  jwt.sign({
+    token: text,
+  }, secret, {
+    expiresIn: ttl,
+  }, (err, token) => {
+    if (err) {
+      done(err);
+    } else {
+      done(undefined, token);
+    }
+  });
 };
 
-const decrypt = (text) => {
-  const decipher = crypto.createDecipher(algorithm, password);
-  return decipher.update(text, 'hex', 'utf8') + decipher.final('utf8');
+const decrypt = (text, done) => {
+  jwt.verify(text, secret, (err, decoded) => {
+    if (err) {
+      done(err);
+    } else {
+      done(undefined, decoded);
+    }
+  });
 };
-
-const userCache = new NodeCache({
-  stdTTL: ttl,
-  checkperiod: check,
-});
 
 /**
  * Process the authorization: Basic header
@@ -57,19 +61,22 @@ module.exports.basicLDAP = function basicLDAP(passport) {
       }
 
       // Authentication succeeded so login the user
-      req.user = user;  // req.logIn() is not called because no session is needed
+      req.user = user; // req.logIn() is not called because no session is needed
 
       // Encrypt the header because it contains the password
-      const basic = encrypt(authorization);
+      return encrypt(authorization, (error, basic) => {
+        if (error) {
+          next(error);
+        } else {
+          // Create the bearer token
+          const base64 = new Buffer(basic).toString('base64');
 
-      // Create the bearer token and cache the basic header
-      const token = new Buffer(uuid.v4()).toString('base64');
-      userCache.set(token, basic);
-
-      // Put the token in the response and send
-      const reply = info || {};
-      reply.token = token;
-      return res.status(200).json(reply);
+          // Put the token in the response and send
+          const reply = info || {};
+          reply.token = base64;
+          res.status(200).json(reply);
+        }
+      });
     })(req, res, next);
   };
 };
@@ -78,42 +85,51 @@ module.exports.basicLDAP = function basicLDAP(passport) {
  * Process the authorization: Bearer header
  */
 module.exports.bearer = function bearer(passport) {
+  const send401 = (req, res, next) => {
+    res.set('WWW-Authenticate', 'Bearer').status(401).json({
+      message: 'Login to get a new bearer token',
+    });
+
+    next();
+  };
+
   return (req, res, next) => {
     const authorization = req.get('Authorization');
-    const token = authorization ? authorization.match(/bearer\s+([\S]+)$/i) || [] : [];
-    const cached = token[1] ? userCache.get(token[1]) : undefined;
+    const key = authorization ? authorization.match(/bearer\s+([\S]+)$/i) || [] : [];
 
     if (!authorization) {
       res.redirect('/login');
       return next();
     }
 
-    if (!cached) {
-      // Either basic authentication -or- an expired or invalid bearer authentication
-      res.set('WWW-Authenticate', 'Bearer').status(401).json({
-        message: 'Login to get a new bearer token',
-      });
-      return next();
+    if (!key[1]) {
+      // Invalid bearer authentication
+      return send401(req, res, next);
     }
 
-    // Decrypt the cached basic authorization header and override the header
-    const basic = decrypt(cached);
-    req.headers.authorization = basic;
-
-    // Do the authentication with the overridden header
-    return passport.authenticate('ldapauth', (err, user) => {
+    // Validate token is stil valid and decrypt the basic authorization header
+    const token = new Buffer(key[1], 'base64').toString('UTF-8');
+    return decrypt(token, (err, basic) => {
       if (err) {
-        return next(err);
+        return (err.name === 'TokenExpiredError') ? send401(req, res, next) : next(err);
       }
 
-      if (!user) {
-        // Authentication failed
-        return res.redirect('/login');
-      }
+      // Override the authorization header
+      req.headers.authorization = basic.token;
 
-      // Authentication succeeded so login the user
-      req.user = user;  // req.logIn() is not called because no session is needed
-      return next();
-    })(req, res, next);
+      // Do the authentication with the overridden header
+      return passport.authenticate('ldapauth', (error, user) => {
+        if (error) {
+          next(error);
+        } else if (!user) {
+          // Authentication failed
+          res.redirect('/login');
+        } else {
+          // Authentication succeeded so login the user
+          req.user = user; // req.logIn() is not called because no session is needed
+          next();
+        }
+      })(req, res, next);
+    });
   };
 };

--- a/auth.js
+++ b/auth.js
@@ -111,7 +111,7 @@ module.exports.bearer = function bearer(passport) {
       return send401(req, res, next);
     }
 
-    // Validate token is stil valid and decrypt the basic authorization header
+    // Validate token is still valid and decrypt the basic authorization header
     const token = new Buffer(key[1], 'base64').toString('UTF-8');
     return decrypt(token, (err, basic) => {
       if (err) {

--- a/auth.js
+++ b/auth.js
@@ -38,15 +38,19 @@ const decrypt = (text, done) => {
  * Process the authorization: Basic header
  */
 module.exports.basicLDAP = function basicLDAP(passport) {
+  const send401 = (msg, req, res, next) => {
+    res.set('WWW-Authenticate', 'Basic').status(401).json(msg || {});
+    next();
+  };
+
   return (req, res, next) => {
     const authorization = req.get('Authorization');
 
     if (!authorization) {
       // Send the request for Basic Authentication and exit
-      res.set('WWW-Authenticate', 'Basic').status(401).json({
+      return send401({
         message: 'Missing header',
-      });
-      return next();
+      }, req, res, next);
     }
 
     // Do the authentication
@@ -57,7 +61,7 @@ module.exports.basicLDAP = function basicLDAP(passport) {
 
       if (!user) {
         // Authentication failed
-        return res.set('WWW-Authenticate', 'Basic').status(401).json(info || {});
+        return send401(info, req, res, next);
       }
 
       // Authentication succeeded so login the user

--- a/config/default.json
+++ b/config/default.json
@@ -32,7 +32,8 @@
     "security": {
       "groups": {
         "reinier admin": ".*",
-        "reinier user": ["(GET|POST).*"]
+        "reinier editor": ["GET /", "(GET|PUT|POST|DELETE) /edit/.*"],
+        "reinier blogger": ["GET /", "(GET|PUT|POST|DELETE) /blog/.*"]
       }
     }
   },

--- a/config/default.json
+++ b/config/default.json
@@ -11,12 +11,9 @@
       }
     },
     "auth": {
-      "crypt": {
-        "password" : "OVERRIDE"
-      },
-      "cache": {
-        "ttl": 10800,
-        "check": 360
+      "token": {
+        "secret" : "OVERRIDE",
+        "ttl": 10800
       }
     }
   },

--- a/config/testing.json
+++ b/config/testing.json
@@ -1,0 +1,16 @@
+{
+  "test": {
+    "admin": {
+      "username": "OVERRIDE",
+      "password": "OVERRIDE"
+    },
+    "editor": {
+      "username": "OVERRIDE",
+      "password": "OVERRIDE"
+    },
+    "blogger": {
+      "username": "OVERRIDE",
+      "password": "OVERRIDE"
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -79,3 +79,5 @@ redirect.all('*', (req, res) => {
 
 const open = http.createServer(redirect);
 open.listen(openPort, listening(open));
+
+module.exports = app; // for testing

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Web Publishing with Airtable",
   "main": "index.js",
   "scripts": {
-    "test": "make test",
+    "test": "mocha",
     "start": "node index.js"
   },
   "repository": {
@@ -21,19 +21,22 @@
     "basic-auth": "^1.1.0",
     "config": "^1.25.1",
     "express": "^4.14.1",
+    "jsonwebtoken": "^7.3.0",
     "node-cache": "^4.1.1",
     "passport": "^0.3.2",
     "passport-ldapauth": "^1.0.0",
     "rapid-solos": "0.0.25",
     "seneca": "^3.2.2",
-    "seneca-entity": "^1.3.0",
-    "uuid": "^3.0.1"
+    "seneca-entity": "^1.3.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-http": "^3.0.0",
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",
-    "jsdoc": "^3.4.3"
+    "jsdoc": "^3.4.3",
+    "mocha": "^3.2.0"
   },
   "jshintConfig": {
     "node": true,

--- a/test/user-tests.js
+++ b/test/user-tests.js
@@ -68,7 +68,7 @@ describe('User', () => {
     it('with a bad password should fail', (done) => {
       chai.request(server)
         .get('/login')
-        .set('authorization', generateBasicAuth('admin').slice(0, -4))
+        .set('authorization', generateBasicAuth('blogger').slice(0, -4))
         .end((err, res) => {
           res.should.have.status(401);
           res.headers.should.have.property('www-authenticate');
@@ -82,7 +82,7 @@ describe('User', () => {
     it('with a good password should succeed', (done) => {
       chai.request(server)
         .get('/login')
-        .set('authorization', generateBasicAuth('admin'))
+        .set('authorization', generateBasicAuth('blogger'))
         .end((err, res) => {
           res.should.have.status(200);
           res.headers.should.not.have.property('www-authenticate');
@@ -122,7 +122,7 @@ describe('User', () => {
           done();
         });
     });
-    it('with a bearer authentication header should succeed', (done) => {
+    it('with correct bearer authentication header should succeed', (done) => {
       chai.request(server)
         .get('/')
         .set('authorization', generateBearerAuth(token))

--- a/test/user-tests.js
+++ b/test/user-tests.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2017, Three Pawns, Inc. All rights reserved.
+ */
+
+'use strict';
+
+// During the test the env variable is set to test
+process.env.NODE_ENV = 'testing';
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../index');
+const config = require('config').get('test');
+
+const should = chai.should();
+let token;
+
+chai.use(chaiHttp);
+
+const generateBasicAuth = (user) => {
+  const username = config[user].username;
+  const password = config[user].password;
+  const base64 = new Buffer(`${username}:${password}`).toString('base64');
+  return `Basic ${base64}`;
+};
+
+const generateBearerAuth = auth => `Bearer ${auth}`;
+
+// Our parent block
+describe('User', () => {
+  beforeEach((done) => { // Before each test we empty the database
+    /*
+     * Nothing to see here (yet)
+     */
+    done();
+  });
+  /*
+   * Test the /GET route
+   */
+  describe('GET /login', () => {
+    it('without a header should fail', (done) => {
+      chai.request(server)
+        .get('/login')
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.headers.should.have.property('www-authenticate');
+          res.headers['www-authenticate'].should.match(/^Basic/);
+          res.body.should.be.a('object');
+          res.body.should.have.property('message');
+          res.body.message.should.eql('Missing header');
+          done();
+        });
+    });
+    it('with a malformed header should fail', (done) => {
+      chai.request(server)
+        .get('/login')
+        .set('authorization', 'Basic somegobbledygook')
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.headers.should.have.property('www-authenticate');
+          res.headers['www-authenticate'].should.match(/^Basic/);
+          res.body.should.be.a('object');
+          res.body.should.have.property('message');
+          res.body.message.should.eql('Missing credentials');
+          done();
+        });
+    });
+    it('with a bad password should fail', (done) => {
+      chai.request(server)
+        .get('/login')
+        .set('authorization', generateBasicAuth('admin').slice(0, -4))
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.headers.should.have.property('www-authenticate');
+          res.headers['www-authenticate'].should.match(/^Basic/);
+          res.body.should.be.a('object');
+          res.body.should.have.property('message');
+          res.body.message.should.eql('Invalid username/password');
+          done();
+        });
+    });
+    it('with a good password should succeed', (done) => {
+      chai.request(server)
+        .get('/login')
+        .set('authorization', generateBasicAuth('admin'))
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.headers.should.not.have.property('www-authenticate');
+          res.body.should.be.a('object');
+          res.body.should.have.property('token');
+          token = res.body.token;
+          done();
+        });
+    });
+  });
+
+  describe('GET /', () => {
+    it('without an authentication header should fail', (done) => {
+      chai.request(server)
+        .get('/')
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.headers.should.have.property('www-authenticate');
+          res.headers['www-authenticate'].should.match(/^Basic/);
+          res.body.should.be.a('object');
+          res.body.should.have.property('message');
+          res.body.message.should.eql('Missing header');
+          done();
+        });
+    });
+    it('with a basic authentication header should fail', (done) => {
+      chai.request(server)
+        .get('/')
+        .set('authorization', generateBasicAuth('blogger'))
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.headers.should.have.property('www-authenticate');
+          res.headers['www-authenticate'].should.match(/^Bearer/);
+          res.body.should.be.a('object');
+          res.body.should.have.property('message');
+          res.body.message.should.eql('Login to get a new bearer token');
+          done();
+        });
+    });
+    it('with a bearer authentication header should succeed', (done) => {
+      chai.request(server)
+        .get('/')
+        .set('authorization', generateBearerAuth(token))
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.headers.should.not.have.property('www-authenticate');
+          should.exist(res.text);
+          res.text.should.match(/<html>/);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented feature that allows users to login to the system.
1. Authentication is now stateless using json web tokens (jwt)
2. Removed dependency on uuid and node-cache
3. Created scaffolding for testing which added dependencies on chai, chai-http, and mocha
4. Added user-tests (testing login)
5. Added test configurations

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #2 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Security must be built into the system from the very beginning.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wrote unit tests using mocha/chai to ensure both success and failure scenarios are executed.  All 7 test pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
